### PR TITLE
Update python_version 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/macvendors.json
+++ b/macvendors.json
@@ -16,7 +16,7 @@
     "main_module": "macvendors_connector.py",
     "min_phantom_version": "5.1.0",
     "fips_compliant": true,
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "latest_tested_versions": [
         "MAC Vendors Cloud, 2012 on 09/13/2021"
     ],

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/update-python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/update-python-versions-3.13-phase1and2)