### PR TITLE
fix: reject MacVendors HTTP error responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2018-2025 Splunk Inc.
+   Copyright (c) 2018-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: MAC Vendors
-Copyright (c) 2018-2025 Splunk Inc.
+Copyright (c) 2018-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/macvendors.json
+++ b/macvendors.json
@@ -9,7 +9,7 @@
     "product_name": "MAC Vendors",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2018-2025 Splunk Inc.",
+    "license": "Copyright (c) 2018-2026 Splunk Inc.",
     "app_version": "2.1.11",
     "utctime_updated": "2025-09-04T22:17:23.964972Z",
     "package_name": "phantom_macvendors",

--- a/macvendors_connector.py
+++ b/macvendors_connector.py
@@ -1,6 +1,6 @@
 # File: macvendors_connector.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/macvendors_connector.py
+++ b/macvendors_connector.py
@@ -129,16 +129,17 @@ class MacVendorsConnector(BaseConnector):
 
         # Process each 'Content-Type' of response separately
 
-        # Process a json response
-        if "text" in r.headers.get("Content-Type", ""):
-            return RetVal(phantom.APP_SUCCESS, r.text)
-
         # Process an HTML resonse, Do this no matter what the api talks.
         # There is a high chance of a PROXY in between phantom and the rest of
         # world, in case of errors, PROXY's return HTML, this function parses
         # the error and adds it to the action_result.
         if "html" in r.headers.get("Content-Type", ""):
             return self._process_html_response(r, action_result)
+
+        # The API returns successful lookups as plain text. Do not treat text
+        # error responses, such as rate-limit messages, as vendor data.
+        if "text" in r.headers.get("Content-Type", "") and 200 <= r.status_code < 399:
+            return RetVal(phantom.APP_SUCCESS, r.text)
 
         # it's not content-type that is to be parsed, handle an empty response
         if not r.text:

--- a/macvendors_consts.py
+++ b/macvendors_consts.py
@@ -1,6 +1,6 @@
 # File: macvendors_consts.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Reject upstream HTTP errors instead of recording their response bodies as vendor data.


### PR DESCRIPTION
## Summary

- route HTML error responses through the connector error parser
- accept plain-text vendor data only for successful HTTP status codes
- refresh generated connector artifacts with dev-cicd-tools v2.2.4

## Tracking

- PAPP-38228
- PSAAS-31982
- Parent epic: ESPM-5228

## Validation

- `pre-commit run --all-files`

Created by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38228
- PSAAS: PSAAS-31982
- Written by Codex.